### PR TITLE
REFACTOR: Revert string rep of DotDict

### DIFF
--- a/mh/core.py
+++ b/mh/core.py
@@ -97,7 +97,7 @@ class DotDict:
         self.__dict__.update(DotDict.get_dict(d))
 
     def str(self):
-        return dict_dump(self.__dict__)
+        return str(self.__dict__)
 
     def dict(self):
         return self.__dict__

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="masthay_helpers",
-    version="0.2.95",
+    version="0.2.96",
     author="Tyler Masthay",
     description="Helper functions for repetitive and useful tasks",
     long_description=open("README.md").read(),


### PR DESCRIPTION
str(d) == str(d.__dict__) is new behavior.
This is because YAML conversion messes up the DataFactory deployment. It is arguably less confusing as well.